### PR TITLE
Removing watermark background to enforce sponsor brand guidelines

### DIFF
--- a/eventos/omegaup-gala-2021/index.html
+++ b/eventos/omegaup-gala-2021/index.html
@@ -69,7 +69,7 @@
     </section>
 
     <section class="header1 cid-s48MCQYojq mbr-fullscreen mbr-parallax-background" id="header1-f">
-      <div class="mbr-overlay" style="opacity: 0.8; background-color: rgb(255, 255, 255)"></div>
+      <div class="mbr-overlay" style="opacity: 1.0; background-color: rgb(255, 255, 255)"></div>
 
       <div class="align-center container-fluid">
         <div class="row justify-content-center">


### PR DESCRIPTION
Brand guidelines specify that logo should have a solid white background when using their main logos (e.g. [F5 Creative Guideline, p. 10](https://www.f5.com/pdf/f5/F5-Creative-Guidelines.pdf)). This conflicts with our watermark background.

Simplest fix is to remove the watermark background.

Example of logo with watermark background:
![image](https://user-images.githubusercontent.com/684205/132972187-6c58061e-1a8f-4803-bd79-7e5002840f0c.png)
