### PR TITLE
Clarify repository status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# ⚠️ Notice
+
+> The current omegaUp.org website is no longer built from this repository. Fixes and updates to the live website are now managed in Wix.
+
+> Feel free to report issues related to the live website here, but please note that pull requests against this repository will generally not be merged, as this code is no longer used in production.
+
+> The rest of this repository is preserved for historical reference.
+
 # Quick Start
 
 Install node, then npm install, then gulp.


### PR DESCRIPTION
Add a notice explaining that the current omegaUp.org website is no longer built from this repository and is now maintained in Wix

The notice also clarifies that issues for the live website are still welcome, but pull requests against this repository will generally not be merged since this code is no longer used in production